### PR TITLE
Support #![no_std] from Rust 1.36.0 and simplify method signature for smart contract functions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,9 @@ members = [
 	"examples/nft",
 	"examples/chat"
 ]
+
+[profile.release]
+opt-level = "z"
+panic = 'abort'
+debug = false
+lto = true

--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/smart-contract.svg)](https://crates.io/crates/smart-contract)
 
 Write smart contracts for Wavelet in Rust.
+
+# Useage
+
+`cargo build --target=wasm32-unknown-unknown`cargo build --target=wasm32-unknown-unknown

--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@
 [![Discord Chat](https://img.shields.io/discord/458332417909063682.svg)](https://discord.gg/dMYfDPM)
 [![crates.io](https://img.shields.io/crates/v/smart-contract.svg)](https://crates.io/crates/smart-contract)
 
-Write smart contracts for Wavelet in Rust.
+Write decentralized applications for Wavelet in Rust.
 
-# Useage
+## Usage
 
-`cargo build --target=wasm32-unknown-unknown`
+`cargo build --release --target=wasm32-unknown-unknown`
+
+## Tutorials
+
+- [Build A Decentralized Chat Using JavaScript & Rust (WebAssembly)](https://medium.com/perlin-network/build-a-decentralized-chat-using-javascript-rust-webassembly-c775f8484b52)
+- [Build a Decentralized Todo App Using Vue.js & Rust (WebAssembly) via Wavelet](https://medium.com/@jjmace01/build-a-decentralized-todo-app-using-vue-js-rust-webassembly-5381a1895beb)

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Write smart contracts for Wavelet in Rust.
 
 # Useage
 
-`cargo build --target=wasm32-unknown-unknown`cargo build --target=wasm32-unknown-unknown
+`cargo build --target=wasm32-unknown-unknown`

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 authors = ["Kenta Iwasaki <kenta@perlin.net>"]
 edition = "2018"
 
-[profile.release]
-lto = true
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/examples/lucky-draw/Cargo.toml
+++ b/examples/lucky-draw/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 authors = ["Abby <abbychau@gmail.com>"]
 edition = "2018"
 
-[profile.release]
-lto = true
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/examples/lucky-draw/src/lib.rs
+++ b/examples/lucky-draw/src/lib.rs
@@ -46,16 +46,14 @@ impl LuckyDraw {
         LuckyDraw(Contract::init(params), 0)
     }
 
-    fn lucky_draw(&mut self, params: &mut Parameters) -> Result<(), Box<dyn Error>> {
+    fn lucky_draw(&mut self, params: &mut Parameters) -> Result<(), String> {
         let amount: u64 = params.read();
         if amount > 10 {
-            return Err(Box::new(LuckyDrawError::AmountTooHigh));
+            return Err(LuckyDrawError::AmountTooHigh.to_string());
         }
 
         if self.1 == ::std::u64::MAX {
-            return Err(Box::new(LuckyDrawError::CustomError(
-                "Counter is full".to_string(),
-            )));
+            return Err(LuckyDrawError::CustomError("Counter is full".to_string()).to_string());
         }
         self.1 += 1;
 

--- a/examples/nft/Cargo.toml
+++ b/examples/nft/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 authors = ["Abby <abbychau@gmail.com>"]
 edition = "2018"
 
-[profile.release]
-lto = true
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/examples/nft/src/lib.rs
+++ b/examples/nft/src/lib.rs
@@ -4,7 +4,6 @@
 //! An example non-fungible token would be CryptoKitties.
 
 use std::collections::HashMap;
-use std::error::Error;
 
 use smart_contract::payload::Parameters;
 use smart_contract_macros::smart_contract;
@@ -23,7 +22,7 @@ impl Ownable {
         }
     }
 
-    fn create_ownable(&mut self, params: &mut Parameters) -> Result<(), Box<dyn Error>> {
+    fn create_ownable(&mut self, params: &mut Parameters) -> Result<(), String> {
         let proposed_id = params.read::<[u8; 32]>();
 
         if self.ownerships.contains_key(&proposed_id) {
@@ -35,7 +34,7 @@ impl Ownable {
         Ok(())
     }
 
-    fn transfer_ownership(&mut self, params: &mut Parameters) -> Result<(), Box<dyn Error>> {
+    fn transfer_ownership(&mut self, params: &mut Parameters) -> Result<(), String> {
         let recipient = params.read::<[u8; 32]>();
         let item_id = params.read::<[u8; 32]>();
 

--- a/examples/recursive-invocation/src/lib.rs
+++ b/examples/recursive-invocation/src/lib.rs
@@ -20,7 +20,7 @@ impl Contract {
             destination: id,
             amount: 0,
             invocation: Some(Invocation {
-                gas_limit: 100000,
+                gas_limit: 1000000,
                 gas_deposit: 0,
                 func_name: b"bomb".to_vec(),
                 func_params: id.to_vec(),

--- a/examples/recursive-invocation/src/lib.rs
+++ b/examples/recursive-invocation/src/lib.rs
@@ -1,7 +1,6 @@
-//! This contract ecursively invokes itself.
+//! This contract recursively invokes itself.
 //! DO NOT invoke this contract with real money.
-use std::error::Error;
-
+//!
 use smart_contract::payload::Parameters;
 use smart_contract::transaction::{Transaction, Transfer, Invocation};
 use smart_contract_macros::smart_contract;
@@ -14,19 +13,21 @@ impl Contract {
         Self {}
     }
 
-    fn bomb(&mut self, params: &mut Parameters) -> Result<(), Box<dyn Error>> {
-        // Create and send transaction.
+    fn bomb(&mut self, params: &mut Parameters) -> Result<(), String> {
         let id: [u8; 32] = params.read();
+
         Transfer {
             destination: id,
             amount: 0,
             invocation: Some(Invocation {
                 gas_limit: 100000,
+                gas_deposit: 0,
                 func_name: b"bomb".to_vec(),
                 func_params: id.to_vec(),
             })
         }
         .send_transaction();
+
         Ok(())
     }
 }

--- a/examples/token/Cargo.toml
+++ b/examples/token/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 authors = ["Kenta Iwasaki <kenta@perlin.net>"]
 edition = "2018"
 
-[profile.release]
-lto = true
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/examples/token/src/lib.rs
+++ b/examples/token/src/lib.rs
@@ -7,7 +7,6 @@
 //! Feel free to change up this contract and deploy your own
 //! cryptocurrency token on Wavelet!
 use std::collections::HashMap;
-use std::error::Error;
 
 use smart_contract::debug;
 use smart_contract::payload::Parameters;
@@ -29,7 +28,7 @@ impl Token {
         Self { balances }
     }
 
-    fn balance(&mut self, params: &mut Parameters) -> Result<(), Box<dyn Error>> {
+    fn balance(&mut self, params: &mut Parameters) -> Result<(), String> {
         let wallet_address: [u8; 32] = params.read();
 
         let wallet_balance = match self.balances.get(&wallet_address) {
@@ -42,7 +41,7 @@ impl Token {
         Ok(())
     }
 
-    fn transfer(&mut self, params: &mut Parameters) -> Result<(), Box<dyn Error>> {
+    fn transfer(&mut self, params: &mut Parameters) -> Result<(), String> {
         let sender = params.sender;
 
         let recipient: [u8; 32] = params.read();

--- a/examples/transfer-back/Cargo.toml
+++ b/examples/transfer-back/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 authors = ["losfair <zhy20000919@hotmail.com>"]
 edition = "2018"
 
-[profile.release]
-lto = true
-
 [lib]
 crate-type = ["cdylib"]
 

--- a/examples/transfer-back/src/lib.rs
+++ b/examples/transfer-back/src/lib.rs
@@ -4,8 +4,6 @@
 //! Overall a simple example of registering a function to get called when
 //! the smart contract receives PERLs, and on how to create and send PERLs
 //! to a provided destination wallet address.
-use std::error::Error;
-
 use smart_contract::payload::Parameters;
 use smart_contract::transaction::{Transaction, Transfer};
 use smart_contract_macros::smart_contract;
@@ -18,7 +16,7 @@ impl Contract {
         Self {}
     }
 
-    fn on_money_received(&mut self, params: &mut Parameters) -> Result<(), Box<dyn Error>> {
+    fn on_money_received(&mut self, params: &mut Parameters) -> Result<(), String> {
         // Create and send transaction.
         Transfer {
             destination: params.sender,

--- a/smart-contract-macros/src/lib.rs
+++ b/smart-contract-macros/src/lib.rs
@@ -129,7 +129,7 @@ impl<'ast> Visit<'ast> for ContractVisitor {
                         _ => match &func.decl.output {
                             syn::ReturnType::Type(_, typ) => {
                                 if quote!(#typ).to_string() != "Result < (  ) , String >"
-                                    && quote!(#typ).to_string() != "Result < (  ) , String >"
+                                    && quote!(#typ).to_string() != "Result < () , String >"
                                 {
                                     panic!("Smart contract functions need to return Result<(), String>.")
                                 }

--- a/smart-contract/Cargo.toml
+++ b/smart-contract/Cargo.toml
@@ -7,5 +7,8 @@ license = "MIT"
 repository = "https://github.com/perlin-network/smart-contract-rs"
 edition = "2018"
 
-[profile.release]
-lto = true
+[dependencies]
+wee_alloc = "0.4.4"
+
+[features]
+no_std = []

--- a/smart-contract/src/lib.rs
+++ b/smart-contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(core_intrinsics, alloc_error_handler)]
+#![feature(core_intrinsics, alloc_error_handler, maybe_uninit)]
 
 extern crate alloc;
 extern crate wee_alloc;

--- a/smart-contract/src/lib.rs
+++ b/smart-contract/src/lib.rs
@@ -1,9 +1,39 @@
-use std::fmt::{Debug, Formatter, Result};
+#![no_std]
+#![feature(core_intrinsics, alloc_error_handler)]
+
+extern crate alloc;
+extern crate wee_alloc;
+
+use alloc::fmt::{Debug, Formatter, Result};
 
 pub mod crypto;
 pub mod payload;
 pub mod sys;
 pub mod transaction;
+
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+#[cfg(feature = "no_std")]
+#[panic_handler]
+#[no_mangle]
+pub fn panic(info: &core::panic::PanicInfo) -> ! {
+    let msg = info.payload().downcast_ref::<&str>().unwrap();
+
+    unsafe {
+        sys::_result(msg.as_ptr(), msg.len());
+        core::intrinsics::abort();
+    }
+}
+
+#[cfg(feature = "no_std")]
+#[alloc_error_handler]
+#[no_mangle]
+pub fn oom(_: core::alloc::Layout) -> ! {
+    unsafe {
+        core::intrinsics::abort();
+    }
+}
 
 pub fn log(msg: &str) {
     unsafe {

--- a/smart-contract/src/lib.rs
+++ b/smart-contract/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![feature(core_intrinsics, alloc_error_handler, maybe_uninit)]
+#![feature(core_intrinsics, alloc_error_handler)]
 
 extern crate alloc;
 extern crate wee_alloc;

--- a/smart-contract/src/payload.rs
+++ b/smart-contract/src/payload.rs
@@ -1,4 +1,5 @@
-use std::io::Write;
+use alloc::string::String;
+use alloc::{vec, vec::Vec};
 
 pub trait Writeable {
     fn write_to(&self, buffer: &mut Vec<u8>);
@@ -10,8 +11,8 @@ macro_rules! writeable {
             impl Writeable for $x {
                 fn write_to(&self, buffer: &mut Vec<u8>) {
                     unsafe {
-                        let x = ::std::slice::from_raw_parts(self as *const _ as *const u8, ::std::mem::size_of::<Self>());
-                        buffer.write_all(x).unwrap();
+                        let x = ::alloc::slice::from_raw_parts(self as *const _ as *const u8, ::core::mem::size_of::<Self>());
+                        buffer.extend_from_slice(x);
                     }
                 }
             }
@@ -96,13 +97,13 @@ macro_rules! readable {
                     unsafe {
                         let ptr = buffer.as_ptr().offset(*pos as isize);
 
-                        let size = ::std::mem::size_of::<$x>();
+                        let size = ::core::mem::size_of::<$x>();
 
-                        let x = ::std::slice::from_raw_parts(ptr, size);
+                        let x = ::alloc::slice::from_raw_parts(ptr, size);
                         *pos += size as u64;
 
-                        let mut ret: $x = ::std::mem::uninitialized();
-                        ::std::ptr::copy(x.as_ptr(), &mut ret as *mut _ as *mut u8, ::std::mem::size_of::<$x>());
+                        let mut ret: $x = ::core::mem::MaybeUninit::uninit().assume_init();
+                        ::core::ptr::copy(x.as_ptr(), &mut ret as *mut _ as *mut u8, ::core::mem::size_of::<$x>());
 
                         ret
                     }

--- a/smart-contract/src/transaction.rs
+++ b/smart-contract/src/transaction.rs
@@ -1,4 +1,5 @@
 use crate::payload::{Readable, Writeable};
+use alloc::{vec, vec::Vec};
 
 #[repr(u8)]
 pub enum TransactionTag {


### PR DESCRIPTION
crate: allow for pkg to support #![no_std], and have default alloc be wee_alloc
api, macro: have all errors be Strings allocated on heap
cargo: remove as many debug symbols by default, and have default opt level be Oz

This will require updates to documentation here: https://wavelet.perlin.net/docs/smart-contracts